### PR TITLE
Docerk setup for production env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM tiangolo/uvicorn-gunicorn-fastapi:python3.11
+
+COPY ./conquest-server/requirements.txt /app/requirements.txt
+
+RUN pip install --no-cache-dir --upgrade -r /app/requirements.txt
+
+COPY ./conquest-server/app /app/app

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,11 @@
 include .env
 
-runuvicorn:
+dev:
 	uvicorn app.main:app --port 3002 --reload
+
+prod:
+	docker compose up --build -d
+	docker image prune -f
+
+stop:
+	docker compose down

--- a/app/database/postgres_client.py
+++ b/app/database/postgres_client.py
@@ -1,5 +1,4 @@
 import os
-import json
 import psycopg2
 
 from app.utils.logger import get_logger

--- a/app/main.py
+++ b/app/main.py
@@ -37,3 +37,8 @@ app.include_router(admin.router)
 app.include_router(users.router)
 app.include_router(watchlist.router)
 app.include_router(professors.router)
+
+
+@app.get("/")
+async def root():
+    return {"status": "ok"}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,25 @@
 services:
+  conquest-server:
+    container_name: conquest-server
+    image: conquest-server:latest
+    build:
+      context: ../
+      dockerfile: conquest-server/Dockerfile
+    platform: linux/amd64
+    ports:
+      - 8000:8000
+    environment:
+      - PORT=8000
+      - POSTGRES_DB=${POSTGRES_DB}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_HOST=conquest-db
+      - MAILGUN_API_KEY=${MAILGUN_API_KEY}
+      - JWT_SECRET=${JWT_SECRET}
+      - ADMIN_KEY=${ADMIN_KEY}
+    depends_on:
+      - conquest-db
+
   conquest-db:
     container_name: conquest-db
     image: postgres


### PR DESCRIPTION
Added a Dockerfile to build a Guvicorn docker image to run the FastAPI server on multiple processes. Also, updated the docker-compose file to build the new image and serve the server on port `8000`.

The dockerized server can be run with `make prod` and stopped with `make stop`.

This PR also adds a get endpoint to the root for health checks.